### PR TITLE
minor link updates

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       readarr_version: ${{ steps.semantic.outputs.new_release_version }}
-      build_name: ${{ steps.semantic.outputs.new_release_version }}
       should_release: ${{ steps.semantic.outputs.new_release_published }}
       release_type: ${{ steps.semantic.outputs.release_type }}
     steps:
@@ -89,7 +88,7 @@ jobs:
           build-args: |
             VERSION=${{ needs.build_meta.outputs.readarr_version }}
             VENDOR=${{ github.repository_owner }}
-            BRANCH=${{ needs.build_meta.outputs.build_name }}
+            BRANCH=develop
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.build_meta.outputs.readarr_version }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,8 @@
         "./Readarr.Api": "${workspaceFolder}/src/Readarr.Api",
         "./Readarr.Automation.Test": "${workspaceFolder}/src/NzbDrone.Automation.Test",
         "./Readarr.Api.V1": "${workspaceFolder}/src/Readarr.Api.V1",
+        "./Readarr.Host": "${workspaceFolder}/src/NzbDrone.Host",
+        "./Readarr.Common": "${workspaceFolder}/src/NzbDrone.Common",
       }
     },
     {

--- a/frontend/src/System/Status/MoreInfo/MoreInfo.js
+++ b/frontend/src/System/Status/MoreInfo/MoreInfo.js
@@ -37,12 +37,12 @@ class MoreInfo extends Component {
 
           <DescriptionListItemTitle>Source</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://github.com/readarr/Readarr/">github.com/Readarr/Readarr</Link>
+            <Link to="https://github.com/faustvii/Readarr/">github.com/faustvii/Readarr</Link>
           </DescriptionListItemDescription>
 
           <DescriptionListItemTitle>Feature Requests</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://github.com/readarr/Readarr/issues">github.com/Readarr/Readarr/issues</Link>
+            <Link to="https://github.com/faustvii/Readarr/issues">github.com/faustvii/Readarr/issues</Link>
           </DescriptionListItemDescription>
 
         </DescriptionList>


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflow, project configuration, and frontend links. The most important changes involve modifying the Docker build process, updating VS Code project paths, and changing repository links in the frontend.

### CI/CD Workflow Updates:
* [`.github/workflows/docker-build.yml`](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L20): Removed the `build_name` output and set the `BRANCH` build argument to `develop` instead of using the `build_name` output. This simplifies the workflow configuration and ensures consistency in branch usage. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L20) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L92-R91)

### Project Configuration Updates:
* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R24-R25): Added new project paths for `Readarr.Host` and `Readarr.Common` to the VS Code workspace configuration, improving local development setup.

### Frontend Updates:
* [`frontend/src/System/Status/MoreInfo/MoreInfo.js`](diffhunk://#diff-d4b14fc9c48cb7f5f22c9dc8e89f990736e1cd6712ed7ba7c3e8fdb119dddf5cL40-R45): Updated repository links to point to a new GitHub repository (`faustvii/Readarr`) for both the source code and feature requests.