### PR TITLE
update default metadata and update package provider

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -94,3 +94,47 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.build_meta.outputs.readarr_version }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+  build_and_upload_release_assets:
+    runs-on: ubuntu-latest
+    needs: build_meta
+    if: needs.build_meta.outputs.should_release == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Build Release Artifacts
+        run: |
+          ./build.sh --packages
+        env:
+          READARRVERSION: ${{ needs.build_meta.outputs.readarr_version }}
+
+      - name: Create linux-musl-x64 tarball
+        run: |
+          tar -czf Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz -C _artifacts/linux-musl-x64/net6.0 Readarr
+
+      - name: Get Release
+        id: get_release
+        run: |
+          echo "upload_url=$(gh release view v${{ needs.build_meta.outputs.readarr_version }} --json uploadUrl --jq .uploadUrl)" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz
+          asset_name: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 100
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -122,6 +122,10 @@ jobs:
         run: |
           tar -czf Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz -C _artifacts/linux-musl-x64/net6.0 Readarr
 
+      - name: Compute SHA256 hash
+        run: |
+          sha256sum Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz > Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz.sha256
+
       - name: Get Release
         id: get_release
         run: |
@@ -129,7 +133,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload Release Asset
+      - name: Upload Release Asset (tarball)
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -138,3 +142,13 @@ jobs:
           asset_path: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz
           asset_name: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz
           asset_content_type: application/gzip
+
+      - name: Upload Release Asset (sha256)
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz.sha256
+          asset_name: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz.sha256
+          asset_content_type: text/plain

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,7 @@
         "./Readarr.Api.V1": "${workspaceFolder}/src/Readarr.Api.V1",
         "./Readarr.Host": "${workspaceFolder}/src/NzbDrone.Host",
         "./Readarr.Common": "${workspaceFolder}/src/NzbDrone.Common",
+        "./Readarr.Core.Test": "${workspaceFolder}/src/NzbDrone.Core.Test",
       }
     },
     {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Equ" Version="2.3.0" />
     <PackageVersion Include="FluentAssertions" Version="5.10.3" />
     <PackageVersion Include="IPAddressRange" Version="6.1.0" />
+    <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Polly" Version="8.5.2" />
     <PackageVersion Include="Servarr.FluentMigrator.Runner" Version="3.3.2.9" />
     <PackageVersion Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />

--- a/src/NzbDrone.Common/Cloud/ReadarrCloudRequestBuilder.cs
+++ b/src/NzbDrone.Common/Cloud/ReadarrCloudRequestBuilder.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Common.Cloud
             Services = new HttpRequestBuilder("https://readarr.servarr.com/v1/")
                 .CreateFactory();
 
-            Metadata = new HttpRequestBuilder("https://api.bookinfo.club/v1/{route}")
+            Metadata = new HttpRequestBuilder("https://api.bookinfo.pro/{route}")
                 .CreateFactory();
         }
 

--- a/src/NzbDrone.Core/Readarr.Core.csproj
+++ b/src/NzbDrone.Core/Readarr.Core.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Diacritical.Net" />
     <PackageReference Include="LazyCache" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Octokit" />
     <PackageReference Include="Polly" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Text.Encoding.CodePages" />

--- a/src/NzbDrone.Core/Update/UpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/UpdatePackageProvider.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
-using NzbDrone.Common.Cloud;
-using NzbDrone.Common.EnvironmentInfo;
-using NzbDrone.Common.Http;
-using NzbDrone.Core.Analytics;
-using NzbDrone.Core.Datastore;
+using System.Linq;
+using NzbDrone.Core.Configuration;
+using Octokit;
 
 namespace NzbDrone.Core.Update
 {
@@ -17,75 +14,131 @@ namespace NzbDrone.Core.Update
 
     public class UpdatePackageProvider : IUpdatePackageProvider
     {
-        private readonly IHttpClient _httpClient;
-        private readonly IHttpRequestBuilderFactory _requestBuilder;
-        private readonly IPlatformInfo _platformInfo;
-        private readonly IAnalyticsService _analyticsService;
-        private readonly IMainDatabase _mainDatabase;
+        private const string Owner = "faustvii";
+        private const string Repo = "Readarr";
+        private readonly IGitHubClient _githubClient;
+        private readonly IDeploymentInfoProvider _deploymentInfoProvider;
 
-        public UpdatePackageProvider(IHttpClient httpClient, IReadarrCloudRequestBuilder requestBuilder, IAnalyticsService analyticsService, IPlatformInfo platformInfo, IMainDatabase mainDatabase)
+        public UpdatePackageProvider(IDeploymentInfoProvider deploymentInfoProvider)
         {
-            _platformInfo = platformInfo;
-            _analyticsService = analyticsService;
-            _requestBuilder = requestBuilder.Services;
-            _httpClient = httpClient;
-            _mainDatabase = mainDatabase;
+            _deploymentInfoProvider = deploymentInfoProvider;
+            _githubClient = new GitHubClient(new ProductHeaderValue("ForkReadarr"));
         }
 
         public UpdatePackage GetLatestUpdate(string branch, Version currentVersion)
         {
-            var request = _requestBuilder.Create()
-                                         .Resource("/update/{branch}")
-                                         .AddQueryParam("version", currentVersion)
-                                         .AddQueryParam("os", OsInfo.Os.ToString().ToLowerInvariant())
-                                         .AddQueryParam("arch", RuntimeInformation.OSArchitecture)
-                                         .AddQueryParam("runtime", "netcore")
-                                         .AddQueryParam("runtimeVer", _platformInfo.Version)
-                                         .AddQueryParam("dbType", _mainDatabase.DatabaseType)
-                                         .AddQueryParam("includeMajorVersion", true)
-                                         .SetSegment("branch", branch);
+            var owner = _deploymentInfoProvider.PackageAuthor ?? Owner;
+            var releases = _githubClient.Repository.Release.GetAll(owner, Repo).GetAwaiter().GetResult();
+            var latestRelease = releases
+                .Where(r => !r.Draft && !r.Prerelease)
+                .Select(r => new { Release = r, Version = TryParseVersion(r.TagName) })
+                .Where(x => x.Version != null)
+                .OrderByDescending(x => x.Version)
+                .FirstOrDefault();
 
-            if (_analyticsService.IsEnabled)
-            {
-                // Send if the system is active so we know which versions to deprecate/ignore
-                request.AddQueryParam("active", _analyticsService.InstallIsActive.ToString().ToLower());
-            }
-
-            var update = _httpClient.Get<UpdatePackageAvailable>(request.Build()).Resource;
-
-            if (!update.Available)
+            if (latestRelease == null)
             {
                 return null;
             }
 
-            return update.UpdatePackage;
+            if (latestRelease.Version <= currentVersion)
+            {
+                return null;
+            }
+
+            var tarAsset = latestRelease.Release.Assets.FirstOrDefault(a => a.Name.EndsWith("linux-musl-x64.tar.gz"));
+            var shaAsset = latestRelease.Release.Assets.FirstOrDefault(a => a.Name.EndsWith("linux-musl-x64.tar.gz.sha256"));
+            string hash = null;
+            if (shaAsset != null)
+            {
+                // Download the .sha256 file and parse the hash
+                var shaContent = _githubClient.Connection.Get<string>(new Uri(shaAsset.BrowserDownloadUrl), TimeSpan.FromSeconds(15)).GetAwaiter().GetResult().Body;
+                if (!string.IsNullOrWhiteSpace(shaContent))
+                {
+                    hash = shaContent.Split(new[] { ' ', '\t', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                }
+            }
+
+            return new UpdatePackage
+            {
+                Version = latestRelease.Version,
+                ReleaseDate = latestRelease.Release.CreatedAt.DateTime,
+                Url = tarAsset?.BrowserDownloadUrl ?? latestRelease.Release.HtmlUrl,
+                Branch = branch,
+                Changes = ParseReleaseNotes(latestRelease.Release.Body),
+            };
         }
 
         public List<UpdatePackage> GetRecentUpdates(string branch, Version currentVersion, Version previousVersion)
         {
-            var request = _requestBuilder.Create()
-                                         .Resource("/update/{branch}/changes")
-                                         .AddQueryParam("version", currentVersion)
-                                         .AddQueryParam("os", OsInfo.Os.ToString().ToLowerInvariant())
-                                         .AddQueryParam("arch", RuntimeInformation.OSArchitecture)
-                                         .AddQueryParam("runtime", "netcore")
-                                         .AddQueryParam("runtimeVer", _platformInfo.Version)
-                                         .SetSegment("branch", branch);
+            var releases = _githubClient.Repository.Release.GetAll(Owner, Repo).GetAwaiter().GetResult();
+            var recentReleases = releases
+                .Where(r => !r.Draft && !r.Prerelease)
+                .Select(r => new { Release = r, Version = TryParseVersion(r.TagName) })
+                .Where(x => x.Version != null)
+                .OrderByDescending(x => x.Release.CreatedAt)
+                .Take(10)
+                .Select(x =>
+                {
+                    var asset = x.Release.Assets.FirstOrDefault(a => a.Name.EndsWith("linux-musl-x64.tar.gz"));
+                    return new UpdatePackage
+                    {
+                        Version = x.Version,
+                        Branch = branch,
+                        Url = asset?.BrowserDownloadUrl ?? x.Release.HtmlUrl,
+                        ReleaseDate = x.Release.CreatedAt.DateTime,
+                        Changes = ParseReleaseNotes(x.Release.Body),
+                        Hash = x.Release.CreatedAt.DateTime.ToString(),
+                        FileName = asset?.Name ?? "Readarr.develop.0.0.0-linux-musl-x64.tar.gz"
+                    };
+                })
+                .ToList();
 
-            if (previousVersion != null && previousVersion != currentVersion)
+            return recentReleases;
+        }
+
+        private static Version TryParseVersion(string versionString)
+        {
+            return Version.TryParse(versionString.TrimStart('v'), out var version) ? version : null;
+        }
+
+        private static UpdateChanges ParseReleaseNotes(string body)
+        {
+            var newChanges = new List<string>();
+            var fixedChanges = new List<string>();
+
+            var currentSection = "";
+
+            foreach (var line in body.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
             {
-                request.AddQueryParam("prevVersion", previousVersion);
+                if (line.StartsWith("### Features", StringComparison.OrdinalIgnoreCase))
+                {
+                    currentSection = "new";
+                    continue;
+                }
+
+                if (line.StartsWith("### Bug Fixes", StringComparison.OrdinalIgnoreCase))
+                {
+                    currentSection = "fixed";
+                    continue;
+                }
+
+                if (line.StartsWith("* ", StringComparison.OrdinalIgnoreCase))
+                {
+                    var cleanLine = line[2..].Split(new[] { " (" }, StringSplitOptions.None)[0];
+
+                    if (currentSection == "new")
+                    {
+                        newChanges.Add(cleanLine);
+                    }
+                    else if (currentSection == "fixed")
+                    {
+                        fixedChanges.Add(cleanLine);
+                    }
+                }
             }
 
-            if (_analyticsService.IsEnabled)
-            {
-                // Send if the system is active so we know which versions to deprecate/ignore
-                request.AddQueryParam("active", _analyticsService.InstallIsActive.ToString().ToLower());
-            }
-
-            var updates = _httpClient.Get<List<UpdatePackage>>(request.Build());
-
-            return updates.Resource;
+            return new UpdateChanges { New = newChanges, Fixed = fixedChanges };
         }
     }
 }


### PR DESCRIPTION
This pull request introduces significant updates to the build pipeline, dependency management, and the implementation of the `UpdatePackageProvider` class. The changes include adding a new workflow for building and uploading release assets, updating dependencies to include the `Octokit` library, and refactoring the `UpdatePackageProvider` class to use GitHub's API for fetching release information. Additionally, there are minor updates to metadata URLs and dependency configuration.

### Build Pipeline Enhancements:
* Added a new `build_and_upload_release_assets` job in `.github/workflows/docker-build.yml` to handle building release artifacts, creating tarballs, and uploading them to GitHub releases. This job is conditional on the `should_release` flag and uses the `.NET SDK` and `gh` CLI for operations.
* Updated the `fetch-depth` to `100` and enabled `fetch-tags` in the checkout step of the existing workflow to ensure proper versioning and tag fetching.

### Dependency Updates:
* Added the `Octokit` library as a dependency in `src/Directory.Packages.props` and `src/NzbDrone.Core/Readarr.Core.csproj` to enable interaction with GitHub's API. [[1]](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11R13) [[2]](diffhunk://#diff-7c3d3ce745f9df092c9d16dc4f355859200072b6546c3dccea13ad10414e911eR10)

### Refactoring of `UpdatePackageProvider`:
* Refactored the `UpdatePackageProvider` class to replace HTTP-based update checks with GitHub API calls using `Octokit`. This includes retrieving release information, parsing release notes, and constructing `UpdatePackage` objects. [[1]](diffhunk://#diff-cc4126a34901bef833abac5527121423cddc7aefd0be5011e39054e589548c38L3-R5) [[2]](diffhunk://#diff-cc4126a34901bef833abac5527121423cddc7aefd0be5011e39054e589548c38L20-R122)
* Removed dependencies on `IHttpClient`, `IHttpRequestBuilderFactory`, and other services, simplifying the class's responsibilities.

### Miscellaneous Updates:
* Updated the metadata URL in `ReadarrCloudRequestBuilder` to point to a new domain (`bookinfo.pro`).