### PR TITLE
update provider fixes and attestation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,6 @@
     "vscode": {
       "extensions": ["esbenp.prettier-vscode"]
     }
-  }
+  },
+  "mounts": [{ "source": "./readarr-config", "target": "/home/vscode/.config/Readarr", "type": "bind" }]
 }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,6 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_meta
     if: needs.build_meta.outputs.should_release == 'true'
+    outputs:
+      image_repo: ${{ steps.set_lowercase_repo.outputs.image_repo }}
+      digest: ${{ steps.build_and_push.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -75,10 +78,12 @@ jobs:
         id: set_lowercase_repo
         run: |
           LOWERCASE_REPO=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "image_repo=${LOWERCASE_REPO}" >> $GITHUB_OUTPUT
           echo "IMAGE_REPO=${LOWERCASE_REPO}" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image to GHCR
         uses: docker/build-push-action@v5
+        id: build_and_push
         with:
           context: .
           file: ./Dockerfile
@@ -153,3 +158,21 @@ jobs:
           asset_path: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz.sha256
           asset_name: Readarr.develop.${{ needs.build_meta.outputs.readarr_version }}.linux-musl-x64.tar.gz.sha256
           asset_content_type: text/plain
+
+  attenstation:
+    runs-on: ubuntu-latest
+    needs: build_docker_image
+    if: needs.build_docker_image.outputs.digest != ''
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+      packages: write
+
+    steps:
+      - name: Generate docker image attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ needs.build_docker_image.outputs.image_repo }}
+          subject-digest: ${{ needs.build_docker_image.outputs.digest }}
+          push-to-registry: true

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ _temp_*/**/*
 
 # API doc generation
 .config/
+readarr-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ ARG TARGETARCH
 ARG VENDOR
 ARG VERSION
 ARG BRANCH=develop
+ARG PackageOwner=faustvii
+ARG PackageRepo=readarr
 
 ENV COMPlus_EnableDiagnostics=0 \
     READARR__UPDATE__BRANCH=${BRANCH}
@@ -66,7 +68,7 @@ COPY --from=builder /src/_artifacts/linux-musl-x64/net6.0/Readarr /app/bin/
 RUN rm -rf /app/bin/Readarr.Update
 
 # Create package_info dynamically
-RUN printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[%s](https://github.com/%s)\n" "${READARR__UPDATE__BRANCH}" "${VERSION}" "${VENDOR}" "${VENDOR}" > /app/package_info
+RUN printf "UpdateMethod=docker\nBranch=%s\nPackageVersion=%s\nPackageAuthor=[%s](https://github.com/%s)\nPackageOwner=%s\nPackageRepo=%s\n" "${READARR__UPDATE__BRANCH}" "${VERSION}" "${VENDOR}" "${VENDOR}" "${PackageOwner}" "${PackageRepo}" > /app/package_info
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -12,6 +12,8 @@ namespace NzbDrone.Core.Configuration
     {
         string PackageVersion { get; }
         string PackageAuthor { get; }
+        string PackageRepo { get; }
+        string PackageOwner { get; }
         string PackageGlobalMessage { get; }
         string PackageBranch { get; }
         UpdateMechanism PackageUpdateMechanism { get; }
@@ -48,6 +50,8 @@ namespace NzbDrone.Core.Configuration
                 PackageUpdateMechanism = ReadEnumValue(data, "UpdateMethod", UpdateMechanism.BuiltIn);
                 PackageUpdateMechanismMessage = ReadValue(data, "UpdateMethodMessage");
                 PackageBranch = ReadValue(data, "Branch");
+                PackageRepo = ReadValue(data, "PackageRepo");
+                PackageOwner = ReadValue(data, "PackageOwner");
 
                 ReleaseVersion = ReadValue(data, "ReleaseVersion");
 
@@ -100,6 +104,8 @@ namespace NzbDrone.Core.Configuration
         public string PackageAuthor { get; private set; }
         public string PackageGlobalMessage { get; private set; }
         public string PackageBranch { get; private set; }
+        public string PackageRepo { get; private set; }
+        public string PackageOwner { get; private set; }
         public UpdateMechanism PackageUpdateMechanism { get; private set; }
         public string PackageUpdateMechanismMessage { get; private set; }
 

--- a/src/NzbDrone.Core/Update/UpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/UpdatePackageProvider.cs
@@ -107,7 +107,15 @@ namespace NzbDrone.Core.Update
 
         private static Version TryParseVersion(string versionString)
         {
-            return Version.TryParse(versionString.TrimStart('v'), out var version) ? version : null;
+            var v = versionString.TrimStart('v');
+            var parts = v.Split('.');
+            while (parts.Length < 4)
+            {
+                v += ".0";
+                parts = v.Split('.');
+            }
+
+            return Version.TryParse(v, out var version) ? version : null;
         }
 
         private static UpdateChanges ParseReleaseNotes(string body)

--- a/src/NzbDrone.Core/Update/UpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/UpdatePackageProvider.cs
@@ -28,8 +28,9 @@ namespace NzbDrone.Core.Update
 
         public UpdatePackage GetLatestUpdate(string branch, Version currentVersion)
         {
-            var owner = _deploymentInfoProvider.PackageAuthor ?? Owner;
-            var releases = _githubClient.Repository.Release.GetAll(owner, Repo).GetAwaiter().GetResult();
+            var owner = _deploymentInfoProvider.PackageOwner ?? Owner;
+            var repo = _deploymentInfoProvider.PackageRepo ?? Repo;
+            var releases = _githubClient.Repository.Release.GetAll(owner, repo).GetAwaiter().GetResult();
             var latestRelease = releases
                 .Where(r => !r.Draft && !r.Prerelease)
                 .Select(r => new { Release = r, Version = TryParseVersion(r.TagName) })


### PR DESCRIPTION
This pull request introduces several enhancements and updates across the codebase, focusing on improving configuration, workflow automation, and versioning. Key changes include adding new fields for package metadata, updating workflows to support attestation, and refining version parsing logic.

### Configuration Updates:
* Added `PackageOwner` and `PackageRepo` arguments to the `Dockerfile` and included them in the dynamically generated `package_info` file. This ensures more detailed package metadata is captured. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R41-R42) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L69-R71)

### Workflow Enhancements:
* Updated `.github/workflows/docker-build.yml` to include new outputs (`image_repo` and `digest`) and added an `attestation` job to generate and push Docker image attestations. [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R51-R53) [[2]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R81-R86) [[3]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R161-R178)

### Codebase Improvements:
* Extended `IDeploymentInfoProvider` and its implementation to include `PackageRepo` and `PackageOwner` properties, and updated the `UpdatePackageProvider` to use these new fields for fetching GitHub releases. [[1]](diffhunk://#diff-54c87e555d99554862b007a7ffee1573126eff0d817c3f5ad8c6ddadc29d67bcR15-R16) [[2]](diffhunk://#diff-54c87e555d99554862b007a7ffee1573126eff0d817c3f5ad8c6ddadc29d67bcR53-R54) [[3]](diffhunk://#diff-54c87e555d99554862b007a7ffee1573126eff0d817c3f5ad8c6ddadc29d67bcR107-R108) [[4]](diffhunk://#diff-cc4126a34901bef833abac5527121423cddc7aefd0be5011e39054e589548c38L31-R33)
* Improved version parsing in `UpdatePackageProvider` to handle versions with fewer than four components by padding with `.0`. This ensures compatibility with version comparison logic.

### Development Environment:
* Added a bind mount in `.devcontainer/devcontainer.json` to persist Readarr configuration files in the development container.