### PR TITLE
fix: bookshelf not triggering api calls to backend

### DIFF
--- a/frontend/src/Bookshelf/BookshelfConnector.js
+++ b/frontend/src/Bookshelf/BookshelfConnector.js
@@ -87,10 +87,10 @@ class BookshelfConnector extends Component {
   //
   // Control
 
-  populate = async() => {
+  populate = () => {
     const { items, currentPage } = this.props;
-    if (items && items.length > 0 && (!currentPage || currentPage === 1)) {
-      await fetchBooks();
+    if (!items || items.length === 0 || (!currentPage || currentPage === 1)) {
+      this.props.fetchBooks();
     }
   };
 


### PR DESCRIPTION
This pull request includes a small but important change to the `populate` method in the `BookshelfConnector` class. The change simplifies the method by removing the `async` keyword and directly calling `this.props.fetchBooks()` instead of using `await fetchBooks()`.

* [`frontend/src/Bookshelf/BookshelfConnector.js`](diffhunk://#diff-45a5f93cc85ded62fd62985b60f13c03639c51fc2910228e95816b27425e43b6L90-R93): Simplified the `populate` method by removing the `async` keyword and replacing the `await fetchBooks()` call with a direct call to `this.props.fetchBooks()`. Additionally, the conditional logic was adjusted to handle cases where `items` is missing or empty.