### PR TITLE
fix: bookshelf paging / fetching being borked

### DIFF
--- a/frontend/src/Bookshelf/BookshelfConnector.js
+++ b/frontend/src/Bookshelf/BookshelfConnector.js
@@ -42,8 +42,9 @@ function createMapStateToProps() {
         bookCount: books.bookCount,
         isBooksPopulated: books.isPopulated,
         isSmallScreen: dimensionsState.isSmallScreen,
-        currentPage: books.page, // <-- add this
-        totalPages: books.totalPages // <-- add this
+        currentPage: books.page,
+        totalPages: books.totalPages,
+        totalRecords: books.totalRecords
       };
     }
   );
@@ -68,9 +69,9 @@ class BookshelfConnector extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { items, currentPage, totalPages, isFetching, pageSize } = this.props;
+    const { bookCount, currentPage, totalPages, totalRecords, isFetching } = this.props;
     if (
-      items.length < (pageSize || 50) &&
+      bookCount < totalRecords &&
       currentPage &&
       totalPages &&
       currentPage < totalPages &&
@@ -88,9 +89,11 @@ class BookshelfConnector extends Component {
   // Control
 
   populate = () => {
-    const { items, currentPage } = this.props;
-    if (!items || items.length === 0 || (!currentPage || currentPage === 1)) {
+    const { bookCount, totalRecords } = this.props;
+    if (bookCount === 0) {
       this.props.fetchBooks();
+    } else if (totalRecords > 0 && bookCount < totalRecords) {
+      this.props.fetchBooksNextPage();
     }
   };
 
@@ -135,6 +138,7 @@ BookshelfConnector.propTypes = {
   currentPage: PropTypes.number,
   totalPages: PropTypes.number,
   pageSize: PropTypes.number,
+  totalRecords: PropTypes.number,
   isPopulated: PropTypes.bool.isRequired,
   isFetching: PropTypes.bool.isRequired,
   bookCount: PropTypes.number,


### PR DESCRIPTION
This pull request updates the `BookshelfConnector` component to improve handling of book pagination by introducing a new `totalRecords` property. The changes ensure more accurate tracking of the total number of books and adjust the logic for fetching books accordingly.

### Enhancements to book pagination:

* **Added `totalRecords` to state mapping**: The `createMapStateToProps` function now includes the `totalRecords` property from the `books` state, allowing the component to track the total number of books available. (`frontend/src/Bookshelf/BookshelfConnector.js`, [frontend/src/Bookshelf/BookshelfConnector.jsL45-R47](diffhunk://#diff-45a5f93cc85ded62fd62985b60f13c03639c51fc2910228e95816b27425e43b6L45-R47))

* **Updated `componentDidUpdate` logic**: Replaced the use of `items` and `pageSize` with `bookCount` and `totalRecords` to determine whether additional books need to be fetched. This ensures that the logic is based on the total count of books rather than the length of the `items` array. (`frontend/src/Bookshelf/BookshelfConnector.js`, [frontend/src/Bookshelf/BookshelfConnector.jsL71-R74](diffhunk://#diff-45a5f93cc85ded62fd62985b60f13c03639c51fc2910228e95816b27425e43b6L71-R74))

* **Modified `populate` method**: Adjusted the method to use `bookCount` and `totalRecords` for deciding whether to fetch the first page of books or subsequent pages. This improves the accuracy of the fetch logic. (`frontend/src/Bookshelf/BookshelfConnector.js`, [frontend/src/Bookshelf/BookshelfConnector.jsL91-R96](diffhunk://#diff-45a5f93cc85ded62fd62985b60f13c03639c51fc2910228e95816b27425e43b6L91-R96))

* **Updated PropTypes**: Added `totalRecords` to the `propTypes` definition to ensure proper type-checking for the new property. (`frontend/src/Bookshelf/BookshelfConnector.js`, [frontend/src/Bookshelf/BookshelfConnector.jsR141](diffhunk://#diff-45a5f93cc85ded62fd62985b60f13c03639c51fc2910228e95816b27425e43b6R141))