### PR TITLE
fix: book api fallback not happening

### DIFF
--- a/src/Readarr.Api.V1/Books/BookController.cs
+++ b/src/Readarr.Api.V1/Books/BookController.cs
@@ -75,7 +75,7 @@ namespace Readarr.Api.V1.Books
                 return GetBooksWithSpecificParameters(authorId, bookIds, titleSlug, includeAllAuthorBooks);
             }
 
-            if (paging != null)
+            if (paging != null && paging.Page.HasValue && paging.PageSize.HasValue)
             {
                 return GetBooksWithPagination(paging);
             }


### PR DESCRIPTION
This pull request includes a small but important change to the `GetBooks` method in the `BookController` class. The change ensures that pagination is only applied when both `Page` and `PageSize` are explicitly provided in the `paging` parameter.

* [`src/Readarr.Api.V1/Books/BookController.cs`](diffhunk://#diff-3bee631589cc4ea9e8b2297fc5785ff6944b2b8b9b0225395b375bcd65cf3c73L78-R78): Updated the condition to check that `paging.Page` and `paging.PageSize` have values before calling `GetBooksWithPagination`.