### PR TITLE
fix: ensure book file count is returned in output

### DIFF
--- a/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
+++ b/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
@@ -271,10 +271,10 @@ namespace NzbDrone.Core.Books
                     e.""Links"" as SelectedEditionLinks,
                     e.""Ratings"" as SelectedEditionRatings,
                     COALESCE(s.""Title"", '') as SeriesTitle,
-                    0 as BookFileCount,
-                    1 as BookCount,
+                    COALESCE(bf_stats.""BookFileCount"", 0) as BookFileCount,
+                    CASE WHEN (b.""Monitored"" = 1 AND (b.""ReleaseDate"" < @currentDate OR b.""ReleaseDate"" IS NULL)) OR COALESCE(bf_stats.""BookFileCount"", 0) > 0 THEN 1 ELSE 0 END as BookCount,
                     1 as TotalBookCount,
-                    0 as SizeOnDisk
+                    COALESCE(bf_stats.""SizeOnDisk"", 0) as SizeOnDisk
                 FROM ""Books"" b
                 INNER JOIN ""AuthorMetadata"" am ON b.""AuthorMetadataId"" = am.""Id""
                 INNER JOIN ""Authors"" a ON am.""Id"" = a.""AuthorMetadataId""
@@ -299,11 +299,21 @@ namespace NzbDrone.Core.Books
                 ) e ON b.""Id"" = e.""BookId""
                 LEFT JOIN ""SeriesBookLink"" sbl ON b.""Id"" = sbl.""BookId""
                 LEFT JOIN ""Series"" s ON sbl.""SeriesId"" = s.""Id""
+                LEFT JOIN (
+                    SELECT
+                        e.""BookId"",
+                        COUNT(bf.""Id"") as BookFileCount,
+                        SUM(COALESCE(bf.""Size"", 0)) as SizeOnDisk
+                    FROM ""Editions"" e
+                    LEFT JOIN ""BookFiles"" bf ON e.""Id"" = bf.""EditionId""
+                    WHERE e.""Monitored"" = 1
+                    GROUP BY e.""BookId""
+                ) bf_stats ON b.""Id"" = bf_stats.""BookId""
                 ORDER BY b.""Id""";
 
             using (var conn = _database.OpenConnection())
             {
-                return conn.Query<BookWithRelatedData>(sql).ToList();
+                return conn.Query<BookWithRelatedData>(sql, new { currentDate = DateTime.UtcNow }).ToList();
             }
         }
 

--- a/src/NzbDrone.Integration.Test/ApiTests/BookApiFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/BookApiFixture.cs
@@ -2,24 +2,42 @@ using System;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Qualities;
+using Readarr.Api.V1.RootFolders;
 
 namespace NzbDrone.Integration.Test.ApiTests
 {
     [TestFixture]
     public class BookApiFixture : IntegrationTest
     {
+        [SetUp]
+        public void Setup()
+        {
+            RootFolders.Post(new RootFolderResource
+            {
+                Name = "TestLibrary",
+                Path = AuthorRootFolder,
+                DefaultMetadataProfileId = 1,
+                DefaultQualityProfileId = 1,
+                DefaultMonitorOption = MonitorTypes.All
+            });
+        }
+
         [Test]
         public void get_books_fallback_should_return_books()
         {
             // Ensure at least one author and book exist
-            var author = EnsureAuthor("3910549", "179778914", "Actus", true);
+            var foreignEditionId = "179778914";
+            var author = EnsureAuthor("3910549", foreignEditionId, "Actus", true);
+            EnsureBookFile(author, 1, foreignEditionId, Quality.MOBI);
 
             // Call the /api/v1/book endpoint with no filters (fallback path)
             var books = Books.All();
 
             // Assert that the response contains at least one book for the author
             books.Should().NotBeNullOrEmpty();
-            var book = books.FirstOrDefault(b => b.AuthorId == author.Id);
+            var book = books.FirstOrDefault(b => b.AuthorId == author.Id && b.ForeignEditionId == foreignEditionId);
             book.Should().NotBeNull();
             book.Title.Should().NotBeNullOrWhiteSpace();
             book.AuthorTitle.Should().NotBeNullOrWhiteSpace();
@@ -41,11 +59,11 @@ namespace NzbDrone.Integration.Test.ApiTests
             book.Images.Should().NotBeNull();
             book.Links.Should().NotBeNull();
             book.Statistics.Should().NotBeNull();
-            book.Statistics.BookFileCount.Should().BeGreaterOrEqualTo(0);
-            book.Statistics.BookCount.Should().BeGreaterOrEqualTo(0);
-            book.Statistics.TotalBookCount.Should().BeGreaterOrEqualTo(0);
-            book.Statistics.SizeOnDisk.Should().BeGreaterOrEqualTo(0);
-            book.Statistics.PercentOfBooks.Should().BeGreaterOrEqualTo(0);
+            book.Statistics.BookFileCount.Should().BeGreaterThan(0);
+            book.Statistics.BookCount.Should().BeGreaterThan(0);
+            book.Statistics.TotalBookCount.Should().BeGreaterThan(0);
+            book.Statistics.SizeOnDisk.Should().BeGreaterThan(0);
+            book.Statistics.PercentOfBooks.Should().BeGreaterThan(0);
             book.Added.Should().NotBe(default(DateTime));
             book.Grabbed.Should().BeFalse();
             book.Id.Should().BeGreaterThan(0);


### PR DESCRIPTION
This pull request enhances the book repository logic to include more accurate statistics and updates the integration tests to reflect these changes. The most important changes involve the addition of a new subquery for book file statistics, modifications to the `BookCount` logic, and updates to the integration tests to validate the new behavior.

### Enhancements to book repository logic:
* Updated the `BookRepository` query to include a subquery (`bf_stats`) that calculates `BookFileCount` and `SizeOnDisk` for monitored editions. This subquery ensures that book statistics are dynamically aggregated based on actual data. (`[src/NzbDrone.Core/Books/Repositories/BookRepository.csR302-R316](diffhunk://#diff-c9e5ab392ab3badfbff9c4ca14cb892dffd21dc1e09cf5c701b2ade659d3ba49R302-R316)`)
* Modified the `BookCount` logic to account for monitored books with release dates in the past or with existing book files. This improves the accuracy of the count. (`[src/NzbDrone.Core/Books/Repositories/BookRepository.csL274-R277](diffhunk://#diff-c9e5ab392ab3badfbff9c4ca14cb892dffd21dc1e09cf5c701b2ade659d3ba49L274-R277)`)

### Updates to integration tests:
* Added a `Setup` method in `BookApiFixture` to initialize a test library with default metadata and quality profiles. This ensures consistent test setup. (`[src/NzbDrone.Integration.Test/ApiTests/BookApiFixture.csR5-R40](diffhunk://#diff-ac26642197b2a9208b73ff6c00e9fad8b2515039643b817f5e09fdeb8b7a445dR5-R40)`)
* Updated the `get_books_fallback_should_return_books` test to include validation for book file creation and to check statistics with stricter conditions (`Should().BeGreaterThan` instead of `Should().BeGreaterOrEqualTo`). This ensures that the test aligns with the updated repository logic. (`[src/NzbDrone.Integration.Test/ApiTests/BookApiFixture.csL44-R66](diffhunk://#diff-ac26642197b2a9208b73ff6c00e9fad8b2515039643b817f5e09fdeb8b7a445dL44-R66)`)