### PR TITLE
fix: use boolean literal for monitored edition query

### DIFF
--- a/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
+++ b/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
@@ -285,12 +285,12 @@ namespace NzbDrone.Core.Books
                         e1.""Links"",
                         e1.""Ratings""
                     FROM ""Editions"" e1
-                    WHERE e1.""Monitored"" = 1
+                    WHERE e1.""Monitored"" = true
                     AND e1.""Id"" = (
                         SELECT MIN(e2.""Id"")
                         FROM ""Editions"" e2
                         WHERE e2.""BookId"" = e1.""BookId""
-                        AND e2.""Monitored"" = 1
+                        AND e2.""Monitored"" = true
                     )
                 ) e ON b.""Id"" = e.""BookId""
                 LEFT JOIN (


### PR DESCRIPTION
## Summary
- replace integer boolean comparisons in BookRepository.GetAllBooksWithRelatedData SQL (Monitored = 1) with PostgreSQL-safe boolean comparisons (Monitored = true)
- fixes /api/v1/book failing on PostgreSQL with operator does not exist: boolean = integer
- restores Add/Search page behavior that depends on this endpoint

## Quick Repro (PostgreSQL)
1. Run Readarr on PostgreSQL and ensure at least one row exists in Editions.
2. Open Add/Search in UI (or call GET /api/v1/book?includeAll=true).
3. Observe 500 and Postgres error 42883: operator does not exist: boolean = integer.
4. In database, run: SELECT COUNT(*) FROM "Editions" e1 WHERE e1."Monitored" = 1; and see the same failure.

## Why this fix works
- PostgreSQL boolean columns cannot be compared to integer literals.
- changing the query to e1."Monitored" = true (and same for e2) removes the type mismatch and restores /api/v1/book.

## Testing
- local dotnet build/tests could not be run in this environment because dotnet SDK is unavailable
- validated failure mode from production logs and reproduced the SQL error directly in PostgreSQL
- validated corrected SQL form (Monitored = true) executes successfully