### PR TITLE
fix: getting all books 500s on postgres

### DIFF
--- a/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
+++ b/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
@@ -294,11 +294,11 @@ namespace NzbDrone.Core.Books
                     )
                 ) e ON b.""Id"" = e.""BookId""
                 LEFT JOIN (
-                    SELECT sbl.""BookId"", s.""Title"" as SeriesTitle
+                    SELECT sbl.""BookId"", s.""Title"" as ""SeriesTitle""
                     FROM ""SeriesBookLink"" sbl
                     LEFT JOIN ""Series"" s ON sbl.""SeriesId"" = s.""Id""
                     INNER JOIN (
-                        SELECT ""BookId"", MIN(""Id"") as MinId
+                        SELECT ""BookId"", MIN(""Id"") as ""MinId""
                         FROM ""SeriesBookLink""
                         GROUP BY ""BookId""
                     ) first_series ON sbl.""BookId"" = first_series.""BookId"" AND sbl.""Id"" = first_series.""MinId""


### PR DESCRIPTION
#### Database Migration
NO

#### Description
On PostgreSQL, `GetAllBooks()` throws, so the unpaged book listing at `GET /api/v1/book` returns a 500.

Two aliases in the raw SQL are declared unquoted but referenced quoted:

```sql
SELECT "BookId", MIN("Id") as MinId
    FROM "SeriesBookLink"
    GROUP BY "BookId"
) first_series ON sbl."BookId" = first_series."BookId" AND sbl."Id" = first_series."MinId"
```

Postgres lowercases the unquoted declaration to `minid`, while the quoted reference is case-sensitive, so it resolves to nothing:

```
42703: column first_series.MinId does not exist
```

`SeriesTitle` has the same mismatch: declared `as SeriesTitle`, consumed as `sbl."SeriesTitle"`.

This quotes the two declarations so they match their references. SQLite is unaffected because it treats identifiers case-insensitively, so the query behaves identically there before and after.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests: unit suite on this branch matches unmodified `develop`. The 4 failures are stale assertions against live Goodreads metadata that has since changed.
- [x] Translation Keys: N/A, no user-facing strings.
- [x] Wiki Updates: N/A.

#### Issues Fixed or Closed by this PR
N/A
